### PR TITLE
change to get env vars for stub from a configmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.7.0 // indirect
+	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/api v0.20.5
 	k8s.io/apimachinery v0.20.5

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/webhook/const.go
+++ b/internal/webhook/const.go
@@ -28,7 +28,7 @@ const (
 	defaultPort    = 443
 	defaultRepo    = "ciscolabs"
 	defaultTag     = "latest"
-	defaultSidecar = "msm-proxy"
+	defaultSidecar = "msm-rtsp-stub"
 	pullPolicyEnv  = "IMAGE_PULL_POLICY"
 	repoEnv        = "REPO"
 	tagEnv         = "TAG"
@@ -40,8 +40,7 @@ const (
 	msmServiceName   = "msm-admission-webhook-svc"
 	msmName          = "msm-admission-webhook"
 	msmNamespace     = "default"
-	msmVolume        = "msm-volume"
-	msmVolumeCfg     = "msm-proxy-cfg"
+	msmConfigMap     = "msm-sidecar-cfg"
 
 	// k8s-specific values
 	deployment                = "Deployment"


### PR DESCRIPTION
now uses a config map to get env vars for the stub.

no need for stub to have a config map itself so removed all that.

current code hard-wires the env var names.  Should be possible to read them from the file and iterate?