### PR TITLE
Start a simple liveness HTTP server

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -64,6 +65,15 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Could not initialize admission webhook, aborting with error=%s", err)
 	}
+
+	livenessMux := http.NewServeMux()
+	livenessMux.HandleFunc("/livenessz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	go func() {
+		logger.Info("Starting Liveness server")
+		http.ListenAndServe(":8080", livenessMux)
+	}()
 
 	startServerErr := make(chan error)
 	go func() {


### PR DESCRIPTION
Adds a liveness probe to the admission webhook.

Considering the simplicity of the webhook only a liveness probe was added which ensures the pod can server http 
responses. 

The changes to the webhook deployment  to include the probe is in a different PR. This change should be merged first.
